### PR TITLE
feat: Implement import/export functionality for StudentSessionApplications

### DIFF
--- a/arkad/arkad/settings.py
+++ b/arkad/arkad/settings.py
@@ -75,6 +75,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django_celery_beat",
+    "import_export",
     "companies",
     "user_models",
     "student_sessions",

--- a/arkad/requirements.txt
+++ b/arkad/requirements.txt
@@ -21,9 +21,11 @@ constantly==23.10.4
 cron_descriptor==2.0.6
 cryptography==44.0.1
 daphne==4.2.1
+diff-match-patch==20241021
 Django==5.2
 django-celery-beat==2.8.1
 django-cors-headers==4.7.0
+django-import-export==4.3.10
 django-ninja==1.4.1
 django-pydantic-field==0.3.13
 django-redis==6.0.0
@@ -66,6 +68,7 @@ service-identity==24.2.0
 setuptools==75.8.1
 six==1.17.0
 sqlparse==0.5.3
+tablib==3.8.0
 tomli==2.2.1
 Twisted==24.11.0
 txaio==23.1.1

--- a/arkad/requirements.txt
+++ b/arkad/requirements.txt
@@ -72,6 +72,7 @@ tablib==3.8.0
 tomli==2.2.1
 Twisted==24.11.0
 txaio==23.1.1
+types-django-import-export==4.3.0.20250822
 types-pytz==2025.2.0.20250809
 types-PyYAML==6.0.12.20241230
 typing_extensions==4.12.2

--- a/arkad/student_sessions/admin.py
+++ b/arkad/student_sessions/admin.py
@@ -1,41 +1,52 @@
+from typing import Any
+
 from django.contrib import admin
+from django.http import HttpRequest
 from import_export.admin import ImportExportModelAdmin
 from .models import StudentSession, StudentSessionApplication, StudentSessionTimeslot
 from .import_export_resources import StudentSessionApplicationResource
 
+
 @admin.register(StudentSessionApplication)
-class StudentSessionApplicationAdmin(ImportExportModelAdmin):
+class StudentSessionApplicationAdmin(ImportExportModelAdmin):  # type: ignore[type-arg]
     resource_classes = [StudentSessionApplicationResource]
 
     # --- Configuration for a better admin list view ---
 
-    list_display = ('user', 'get_company', 'status', 'timestamp')
-    search_fields = ('user__first_name', 'user__last_name', 'user__email', 'student_session__company__name')
+    list_display = ("user", "get_company", "status", "timestamp")
+    search_fields = (
+        "user__first_name",
+        "user__last_name",
+        "user__email",
+        "student_session__company__name",
+    )
 
     # This is key for your requirement to export applications for a specific company.
     # It adds a filter sidebar in the admin.
-    list_filter = ('student_session__company', 'status')
+    list_filter = ("student_session__company", "status")
 
     # Make some fields read-only in the admin detail view for safety
-    readonly_fields = ('timestamp',)
+    readonly_fields = ("timestamp",)
 
-    @admin.display(description='Company', ordering='student_session__company')
-    def get_company(self, obj):
+    @admin.display(description="Company", ordering="student_session__company")
+    def get_company(self, obj: StudentSessionApplication) -> str:
         return obj.student_session.company.name
 
     # This method passes keyword arguments to the Resource class's constructor.
-    def get_export_resource_kwargs(self, request, *args, **kwargs):
+    def get_export_resource_kwargs(self, request: HttpRequest, *args: Any, **kwargs: Any) -> dict[str, HttpRequest]:
         """
         Passes the request object to the resource.
         """
         return {"request": request}
 
+
 # You can also register your other models for convenience
 @admin.register(StudentSession)
-class StudentSessionAdmin(admin.ModelAdmin):
-    list_display = ('company', 'booking_open_time', 'booking_close_time')
+class StudentSessionAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
+    list_display = ("company", "booking_open_time", "booking_close_time")
+
 
 @admin.register(StudentSessionTimeslot)
-class StudentSessionTimeslotAdmin(admin.ModelAdmin):
-    list_display = ('student_session', 'start_time', 'duration', 'selected')
-    list_filter = ('student_session__company',)
+class StudentSessionTimeslotAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
+    list_display = ("student_session", "start_time", "duration", "selected")
+    list_filter = ("student_session__company",)

--- a/arkad/student_sessions/admin.py
+++ b/arkad/student_sessions/admin.py
@@ -1,11 +1,41 @@
 from django.contrib import admin
+from import_export.admin import ImportExportModelAdmin
+from .models import StudentSession, StudentSessionApplication, StudentSessionTimeslot
+from .import_export_resources import StudentSessionApplicationResource
 
-from student_sessions.models import (
-    StudentSession,
-    StudentSessionApplication,
-    StudentSessionTimeslot,
-)
+@admin.register(StudentSessionApplication)
+class StudentSessionApplicationAdmin(ImportExportModelAdmin):
+    resource_classes = [StudentSessionApplicationResource]
 
-admin.site.register(StudentSession)
-admin.site.register(StudentSessionApplication)
-admin.site.register(StudentSessionTimeslot)
+    # --- Configuration for a better admin list view ---
+
+    list_display = ('user', 'get_company', 'status', 'timestamp')
+    search_fields = ('user__first_name', 'user__last_name', 'user__email', 'student_session__company__name')
+
+    # This is key for your requirement to export applications for a specific company.
+    # It adds a filter sidebar in the admin.
+    list_filter = ('student_session__company', 'status')
+
+    # Make some fields read-only in the admin detail view for safety
+    readonly_fields = ('timestamp',)
+
+    @admin.display(description='Company', ordering='student_session__company')
+    def get_company(self, obj):
+        return obj.student_session.company.name
+
+    # This method passes keyword arguments to the Resource class's constructor.
+    def get_export_resource_kwargs(self, request, *args, **kwargs):
+        """
+        Passes the request object to the resource.
+        """
+        return {"request": request}
+
+# You can also register your other models for convenience
+@admin.register(StudentSession)
+class StudentSessionAdmin(admin.ModelAdmin):
+    list_display = ('company', 'booking_open_time', 'booking_close_time')
+
+@admin.register(StudentSessionTimeslot)
+class StudentSessionTimeslotAdmin(admin.ModelAdmin):
+    list_display = ('student_session', 'start_time', 'duration', 'selected')
+    list_filter = ('student_session__company',)

--- a/arkad/student_sessions/import_export_resources.py
+++ b/arkad/student_sessions/import_export_resources.py
@@ -1,0 +1,97 @@
+from import_export import resources, fields, widgets
+from .models import StudentSessionApplication
+
+class StudentSessionApplicationStatusWidget(widgets.CharWidget):
+    """
+    Custom widget to handle status values during import/export. Makes sure that the status value is one of the valid choices.
+    """
+
+    def clean(self, value, row=None, *args, **kwargs):
+        valid_statuses = StudentSessionApplication.get_valid_statuses()
+        if value not in valid_statuses:
+            raise ValueError(f"Invalid status '{value}'. Valid statuses are: {valid_statuses}")
+        return super().clean(value, row, *args, **kwargs)
+
+class StudentSessionApplicationResource(resources.ModelResource):
+    """
+    Resource for importing and exporting StudentSessionApplication data.
+
+    Export includes related user and company information.
+    Import is designed to only update the 'status' of an existing application.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request", None)
+        super(StudentSessionApplicationResource, self).__init__(*args, **kwargs)
+
+    # The only mutable field "status"
+    status = fields.Field(
+        attribute='status',
+        column_name='Status',
+        widget=StudentSessionApplicationStatusWidget(),
+    )
+
+    # Fields from the Application model
+    motivation_text = fields.Field(attribute='motivation_text', column_name='Motivation', readonly=True)
+    timestamp = fields.Field(attribute='timestamp', column_name='Application Time', readonly=True)
+
+    # Fields from the related User model
+    first_name = fields.Field(attribute='user__first_name', column_name='First Name', readonly=True)
+    last_name = fields.Field(attribute='user__last_name', column_name='Last Name', readonly=True)
+    email = fields.Field(attribute='user__email', column_name='Email', readonly=True)
+    programme = fields.Field(attribute='user__programme', column_name='Programme', readonly=True)
+    study_year = fields.Field(attribute='user__study_year', column_name='Study Year', readonly=True)
+    master_title = fields.Field(attribute='user__master_title', column_name='Master Title', readonly=True)
+    linkedin = fields.Field(attribute='user__linkedin', column_name='LinkedIn', readonly=True)
+
+    # Field from the related Company model
+    company = fields.Field(attribute='student_session__company__name', column_name='Company', readonly=True)
+
+    # Custom field for the CV
+    cv = fields.Field(column_name='CV', readonly=True)
+
+    def dehydrate_cv(self, application: StudentSessionApplication) -> str:
+        """
+        Gets the absolute URL for the CV.
+        """
+        cv_file = application.cv or application.user.cv
+        if cv_file and hasattr(cv_file, 'url'):
+            # If we have a request object, build an absolute URI.
+            if self.request:
+                return self.request.build_absolute_uri(cv_file.url)
+            # Fallback to the relative URL if no request is available.
+            return cv_file.url
+        return ""
+
+    class Meta:
+        model = StudentSessionApplication
+
+        # This is the key for matching records during import.
+        # We use the application's unique ID.
+        import_id_fields = ('id',)
+
+        # Define the fields to be included in the export/import file.
+        # 'id' is crucial for matching records on import.
+        # 'status' is the only field companies should change.
+        fields = (
+            'id',
+            'company',
+            'status',
+            'first_name',
+            'last_name',
+            'email',
+            'motivation_text',
+            'programme',
+            'study_year',
+            'master_title',
+            'linkedin',
+            'cv',
+            'timestamp',
+        )
+
+        # This ensures that during import, if a row in the file hasn't changed,
+        # it won't be processed.
+        skip_unchanged = True
+
+        # Report which rows were skipped.
+        report_skipped = True

--- a/arkad/student_sessions/import_export_resources.py
+++ b/arkad/student_sessions/import_export_resources.py
@@ -1,18 +1,24 @@
+from typing import cast, Any
+
 from import_export import resources, fields, widgets
 from .models import StudentSessionApplication
+
 
 class StudentSessionApplicationStatusWidget(widgets.CharWidget):
     """
     Custom widget to handle status values during import/export. Makes sure that the status value is one of the valid choices.
     """
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(self, value: Any, row: Any = None, *args: Any, **kwargs: Any) -> Any:
         valid_statuses = StudentSessionApplication.get_valid_statuses()
         if value not in valid_statuses:
-            raise ValueError(f"Invalid status '{value}'. Valid statuses are: {valid_statuses}")
+            raise ValueError(
+                f"Invalid status '{value}'. Valid statuses are: {valid_statuses}"
+            )
         return super().clean(value, row, *args, **kwargs)
 
-class StudentSessionApplicationResource(resources.ModelResource):
+
+class StudentSessionApplicationResource(resources.ModelResource):  # type: ignore[type-arg]
     """
     Resource for importing and exporting StudentSessionApplication data.
 
@@ -20,47 +26,65 @@ class StudentSessionApplicationResource(resources.ModelResource):
     Import is designed to only update the 'status' of an existing application.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any):
         self.request = kwargs.pop("request", None)
         super(StudentSessionApplicationResource, self).__init__(*args, **kwargs)
 
     # The only mutable field "status"
     status = fields.Field(
-        attribute='status',
-        column_name='Status',
+        attribute="status",
+        column_name="Status",
         widget=StudentSessionApplicationStatusWidget(),
     )
 
     # Fields from the Application model
-    motivation_text = fields.Field(attribute='motivation_text', column_name='Motivation', readonly=True)
-    timestamp = fields.Field(attribute='timestamp', column_name='Application Time', readonly=True)
+    motivation_text = fields.Field(
+        attribute="motivation_text", column_name="Motivation", readonly=True
+    )
+    timestamp = fields.Field(
+        attribute="timestamp", column_name="Application Time", readonly=True
+    )
 
     # Fields from the related User model
-    first_name = fields.Field(attribute='user__first_name', column_name='First Name', readonly=True)
-    last_name = fields.Field(attribute='user__last_name', column_name='Last Name', readonly=True)
-    email = fields.Field(attribute='user__email', column_name='Email', readonly=True)
-    programme = fields.Field(attribute='user__programme', column_name='Programme', readonly=True)
-    study_year = fields.Field(attribute='user__study_year', column_name='Study Year', readonly=True)
-    master_title = fields.Field(attribute='user__master_title', column_name='Master Title', readonly=True)
-    linkedin = fields.Field(attribute='user__linkedin', column_name='LinkedIn', readonly=True)
+    first_name = fields.Field(
+        attribute="user__first_name", column_name="First Name", readonly=True
+    )
+    last_name = fields.Field(
+        attribute="user__last_name", column_name="Last Name", readonly=True
+    )
+    email = fields.Field(attribute="user__email", column_name="Email", readonly=True)
+    programme = fields.Field(
+        attribute="user__programme", column_name="Programme", readonly=True
+    )
+    study_year = fields.Field(
+        attribute="user__study_year", column_name="Study Year", readonly=True
+    )
+    master_title = fields.Field(
+        attribute="user__master_title", column_name="Master Title", readonly=True
+    )
+    linkedin = fields.Field(
+        attribute="user__linkedin", column_name="LinkedIn", readonly=True
+    )
 
     # Field from the related Company model
-    company = fields.Field(attribute='student_session__company__name', column_name='Company', readonly=True)
+    company = fields.Field(
+        attribute="student_session__company__name", column_name="Company", readonly=True
+    )
 
     # Custom field for the CV
-    cv = fields.Field(column_name='CV', readonly=True)
+    cv = fields.Field(column_name="CV", readonly=True)
 
     def dehydrate_cv(self, application: StudentSessionApplication) -> str:
         """
         Gets the absolute URL for the CV.
         """
         cv_file = application.cv or application.user.cv
-        if cv_file and hasattr(cv_file, 'url'):
+        if cv_file and hasattr(cv_file, "url"):
             # If we have a request object, build an absolute URI.
             if self.request:
-                return self.request.build_absolute_uri(cv_file.url)
+                return str(self.request.build_absolute_uri(cv_file.url))
             # Fallback to the relative URL if no request is available.
-            return cv_file.url
+            return str(cv_file.url)
         return ""
 
     class Meta:
@@ -68,25 +92,25 @@ class StudentSessionApplicationResource(resources.ModelResource):
 
         # This is the key for matching records during import.
         # We use the application's unique ID.
-        import_id_fields = ('id',)
+        import_id_fields = ("id",)
 
         # Define the fields to be included in the export/import file.
         # 'id' is crucial for matching records on import.
         # 'status' is the only field companies should change.
         fields = (
-            'id',
-            'company',
-            'status',
-            'first_name',
-            'last_name',
-            'email',
-            'motivation_text',
-            'programme',
-            'study_year',
-            'master_title',
-            'linkedin',
-            'cv',
-            'timestamp',
+            "id",
+            "company",
+            "status",
+            "first_name",
+            "last_name",
+            "email",
+            "motivation_text",
+            "programme",
+            "study_year",
+            "master_title",
+            "linkedin",
+            "cv",
+            "timestamp",
         )
 
         # This ensures that during import, if a row in the file hasn't changed,

--- a/arkad/student_sessions/models.py
+++ b/arkad/student_sessions/models.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import UniqueConstraint
 from django.utils import timezone
@@ -15,7 +16,6 @@ from user_models.models import User
 from companies.models import Company
 from django_pydantic_field import SchemaField
 
-
 class StudentSessionApplication(models.Model):
     student_session = models.ForeignKey(
         "StudentSession", on_delete=models.CASCADE, null=False
@@ -30,7 +30,7 @@ class StudentSessionApplication(models.Model):
         null=True,
         blank=True,
     )
-    status = models.CharField(
+    status = models.CharField(  # Todo use an enum
         max_length=10,
         choices=[
             ("pending", "Pending"),
@@ -79,6 +79,9 @@ class StudentSessionApplication(models.Model):
     def is_pending(self) -> bool:
         return self.status == "pending"
 
+    @staticmethod
+    def get_valid_statuses() -> list[str]:
+        return ["pending", "accepted", "rejected"]
 
 class StudentSessionTimeslot(models.Model):
     selected = models.OneToOneField(

--- a/arkad/student_sessions/models.py
+++ b/arkad/student_sessions/models.py
@@ -1,6 +1,5 @@
 from functools import partial
 
-from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import UniqueConstraint
 from django.utils import timezone
@@ -15,6 +14,7 @@ from student_sessions.dynamic_fields import FieldModificationSchema
 from user_models.models import User
 from companies.models import Company
 from django_pydantic_field import SchemaField
+
 
 class StudentSessionApplication(models.Model):
     student_session = models.ForeignKey(
@@ -82,6 +82,7 @@ class StudentSessionApplication(models.Model):
     @staticmethod
     def get_valid_statuses() -> list[str]:
         return ["pending", "accepted", "rejected"]
+
 
 class StudentSessionTimeslot(models.Model):
     selected = models.OneToOneField(

--- a/arkad/student_sessions/tests.py
+++ b/arkad/student_sessions/tests.py
@@ -1,12 +1,8 @@
 import datetime
 
-from django.test import TestCase, Client
-from django.utils import timezone
+from django.test import Client
 
-from companies.models import Company
 from student_sessions.models import (
-    StudentSession,
-    StudentSessionApplication,
     StudentSessionTimeslot,
 )
 from student_sessions.schema import (
@@ -16,6 +12,14 @@ from student_sessions.schema import (
     TimeslotSchemaUser,
 )
 from user_models.models import User
+import tablib
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, RequestFactory
+from django.utils import timezone
+
+from companies.models import Company
+from student_sessions.models import StudentSession, StudentSessionApplication
+from student_sessions.import_export_resources import StudentSessionApplicationResource
 
 
 class StudentSessionTests(TestCase):
@@ -105,7 +109,7 @@ class StudentSessionTests(TestCase):
         session = StudentSession.objects.create(
             company=self.company_user1.company,
             booking_open_time=timezone.now()
-            + datetime.timedelta(days=1),  # Opens in the future
+                              + datetime.timedelta(days=1),  # Opens in the future
             booking_close_time=timezone.now() + datetime.timedelta(days=2),
         )
 
@@ -730,3 +734,144 @@ class StudentSessionTests(TestCase):
             headers=self._get_auth_headers(self.student_users[0]),
         )
         self.assertEqual(resp.status_code, 404)
+
+
+class StudentSessionApplicationResourceTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        """Set up non-modified objects used by all test methods."""
+
+        # Create a dummy CV file for uploads
+        cls.cv_file_content = b"This is a dummy CV."
+        cls.cv_file = SimpleUploadedFile(
+            "test_cv.pdf", cls.cv_file_content, content_type="application/pdf"
+        )
+        cls.user_cv_file = SimpleUploadedFile(
+            "user_cv.pdf", b"This is a user CV.", content_type="application/pdf"
+        )
+
+        cls.user = User.objects.create_user(
+            email="student@example.com",
+            first_name="Test",
+            last_name="Student",
+            programme="Computer Science",
+            study_year=3,
+            master_title="AI and Machine Learning",
+            linkedin="https://linkedin.com/in/teststudent",
+            cv=cls.user_cv_file,
+            username="student@example.com"
+        )
+        cls.company = Company.objects.create(name="TestCorp")
+        cls.student_session = StudentSession.objects.create(company=cls.company)
+
+        cls.application = StudentSessionApplication.objects.create(
+            student_session=cls.student_session,
+            user=cls.user,
+            motivation_text="My detailed motivation for TestCorp.",
+            status="pending",
+            cv=cls.cv_file,
+            timestamp=timezone.now(),
+        )
+
+    def setUp(self):
+        """Set up objects that may be modified by tests."""
+        # The request factory is essential for testing absolute URL generation
+        self.factory = RequestFactory(SERVER_NAME='testserver')
+        # Create a mock request object
+        self.request = self.factory.get('/admin/student_sessions/studentsessionapplication/')
+
+        # Instantiate the resource, passing the mock request
+        self.resource = StudentSessionApplicationResource(request=self.request)
+
+    def test_export_structure_and_content(self):
+        """Verify that the exported data has the correct headers and content."""
+        queryset = StudentSessionApplication.objects.all()
+        dataset = self.resource.export(queryset)
+
+        # 1. Test Headers
+        expected_headers = [
+            'id', 'Company', 'Status', 'First Name', 'Last Name', 'Email',
+            'Motivation', 'Programme', 'Study Year', 'Master Title',
+            'LinkedIn', 'CV', 'Application Time'
+        ]
+        self.assertEqual(dataset.headers, expected_headers)
+
+        # 2. Test Content
+        self.assertEqual(len(dataset), 1)  # We should have one application
+        exported_row = dataset.dict[0]
+
+        self.assertEqual(int(exported_row['id']), self.application.id)
+        self.assertEqual(exported_row['Company'], self.company.name)
+        self.assertEqual(exported_row['Status'], 'pending')
+        self.assertEqual(exported_row['First Name'], self.user.first_name)
+        self.assertEqual(exported_row['Email'], self.user.email)
+        self.assertEqual(exported_row['Motivation'], self.application.motivation_text)
+        self.assertEqual(exported_row['LinkedIn'], self.user.linkedin)
+
+    def test_export_cv_url_is_absolute(self):
+        """Verify that the CV URL is a full, absolute URL."""
+        queryset = StudentSessionApplication.objects.filter(pk=self.application.pk)
+        dataset = self.resource.export(queryset)
+
+        exported_cv_url = dataset.dict[0]['CV']
+
+        # build_absolute_uri creates a URL like 'http://testserver/media/...'
+        expected_url = self.request.build_absolute_uri(self.application.cv.url)
+
+        self.assertEqual(exported_cv_url, expected_url)
+        self.assertTrue(exported_cv_url.startswith('http://'))
+
+    def test_import_successfully_updates_status(self):
+        """Verify that importing a file correctly updates the Status field."""
+        self.assertEqual(self.application.status, 'pending')  # Pre-condition
+
+        headers = ('id', 'Status')
+        row = (self.application.id, 'accepted')
+        dataset = tablib.Dataset(row, headers=headers)
+
+        # Import data, with dry_run=False to commit changes to the DB
+        self.resource.import_data(dataset, dry_run=False)
+
+        # Refresh the object from the database to see the changes
+        self.application.refresh_from_db()
+        self.assertEqual(self.application.status, 'accepted')
+
+    def test_import_only_changes_status_field(self):
+        """
+        Crucial Security Test: Verify that importing cannot change readonly fields.
+        """
+        original_motivation = self.application.motivation_text
+        self.assertNotEqual(original_motivation, "This should not be saved")
+
+        headers = ('id', 'Status', 'Motivation')
+        row = (self.application.id, 'rejected', 'This should not be saved')
+        dataset = tablib.Dataset(row, headers=headers)
+
+        self.resource.import_data(dataset, dry_run=False, raise_errors=True)
+
+        self.application.refresh_from_db()
+
+        # ASSERT: Status was changed
+        self.assertEqual(self.application.status, 'rejected')
+        # ASSERT: Readonly field was NOT changed
+        self.assertEqual(self.application.motivation_text, original_motivation)
+
+    def test_import_with_invalid_status_fails(self):
+        """Verify that importing a row with an invalid status choice results in an error."""
+        self.assertEqual(self.application.status, 'pending')
+
+        headers = ('id', 'Status')
+        # 'shortlisted' is not a valid choice in the model's status field
+        row = (self.application.id, 'shortlisted')
+        dataset = tablib.Dataset(row, headers=headers)
+
+        result = self.resource.import_data(dataset, dry_run=True)
+
+        # Check that the import process reported an error
+        self.assertTrue(result.has_validation_errors())
+        # Check that the specific row has an error
+        self.assertEqual(len(result.invalid_rows), 1)
+
+        # Verify the database was not changed
+        self.application.refresh_from_db()
+        self.assertEqual(self.application.status, 'pending')


### PR DESCRIPTION
This is done using django-import-export and status values are checked, only they are modifyable. And must be one of ["pending", "accepted", "rejected"].

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled data import/export in the admin for student session applications.
  - Export includes applicant/company details and absolute CV URLs; import supports updating status with validation.
  - Improved admin lists, filters, search, and dedicated admin views for sessions and timeslots.
- Chores
  - Added dependencies to support import/export and enabled the related app.
- Tests
  - Added comprehensive tests covering export/import flows, validation, read-only protections, and URL formatting.
- Style
  - Minor formatting and cleanup across multiple files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->